### PR TITLE
chore: PARS-25 Update composer packages for Laravel 10+ support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     ],
     "require": {
         "php": "^8.0",
-        "illuminate/contracts": "~8|~9",
+        "illuminate/contracts": "^8|^9|^10|^11",
         "jcchavezs/zipkin-opentracing": "^2.0",
         "spatie/laravel-package-tools": "^1.9.2"
     },


### PR DESCRIPTION
`illuminate/...` packages follow the main Laravel versions. In order to use these package on our services that run Laravel 10+ we need to allow for those version for our `illuminate/...` packages.